### PR TITLE
ItemPageの追加、予約アイテム一覧の表示,CSSの追加・修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import AddItem from './components/AddItem';
 import Reserve from './components/Reserve/Reserve';
 import { Completed } from './components/Reserve/Completed';
 import MyPage from './components/MyPage';
+import { ItemPage } from './components/Items/ItemPage';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <Route path="/addItem" element={<AddItem />} />
         <Route path="/completed" element={<Completed />} />
         <Route path="/mypage" element={<MyPage />} />
+        <Route path="/item/:id" element={<ItemPage />} />
       </Routes>
     </Router>
   );

--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -13,7 +13,7 @@ export const ItemPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fectItem = async () => {
+    const fetchItem = async () => {
       const result = await axios.get(
         `http://localhost:8000/reservations?item.id=${id}`,
       );
@@ -23,7 +23,7 @@ export const ItemPage = () => {
         setItem(result.data);
       }
     };
-    fectItem();
+    fetchItem();
   }, [id]);
 
   return (
@@ -49,7 +49,7 @@ export const ItemPage = () => {
                   </p>
                   <p>
                     <span>予約時間：</span>
-                    {item.startTime}-{item.endTime}
+                    {item.startTime}~{item.endTime}
                   </p>
                 </div>
                 <div>

--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Reservation } from '../../types/Reservation';
+import styles from '../../styles/ItemPage.module.css';
+import { Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export const ItemPage = () => {
+  const [item, setItem] = useState<Reservation[]>();
+  const [isEmpty, setIsEmpty] = useState(false);
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fectItem = async () => {
+      const result = await axios.get(
+        `http://localhost:8000/reservations?item.id=${id}`,
+      );
+      if (!result.data.length) {
+        setIsEmpty(true);
+      } else {
+        setItem(result.data);
+      }
+    };
+    fectItem();
+  }, [id]);
+
+  return (
+    <>
+      <main className={styles.content}>
+        <div className={styles.titleWrapper}>
+          {isEmpty ? (
+            <p className={styles.title}>現在予約は入っておりません</p>
+          ) : (
+            <p className={styles.title}>予約状況は以下のようになっています</p>
+          )}
+        </div>
+        <div>
+          <ul>
+            {item?.map((item) => (
+              <li key={item.id} className={styles.list}>
+                <div className={styles.listContent}>
+                  <p>{item.title}</p>
+                  <p>{item.item.name}</p>
+                  <p>
+                    <span>日にち：</span>
+                    {item.date}
+                  </p>
+                  <p>
+                    <span>予約時間：</span>
+                    {item.startTime}-{item.endTime}
+                  </p>
+                </div>
+                <div>
+                  <Button
+                    className={styles.btn}
+                    data-testid="btn-nav"
+                    type="submit"
+                    variant="contained"
+                    sx={{
+                      mt: 3,
+                      mb: 2,
+                      bgcolor: '#4970a3',
+                      fontSize: 16,
+                      width: 150,
+                      ':hover': { background: '#3b5a84' },
+                    }}
+                    onClick={() => navigate(`/${item.id}`)}
+                  >
+                    修正・削除
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    </>
+  );
+};

--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -28,7 +28,7 @@ export const ItemPage = () => {
       }
     };
     fetchItem();
-  }, [id]);
+  }, [id, navigate, user]);
 
   return (
     <>

--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -11,8 +11,12 @@ export const ItemPage = () => {
   const [isEmpty, setIsEmpty] = useState(false);
   const { id } = useParams();
   const navigate = useNavigate();
+  const user = sessionStorage.getItem('auth');
 
   useEffect(() => {
+    if (user === null) {
+      navigate('/login');
+    }
     const fetchItem = async () => {
       const result = await axios.get(
         `http://localhost:8000/reservations?item.id=${id}`,

--- a/src/components/Reserve/Completed.tsx
+++ b/src/components/Reserve/Completed.tsx
@@ -1,11 +1,10 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import styles from '../../styles/addReserve.module.css';
 import { Button } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { Reservation } from '../../types/Reservation';
-import { useParams } from 'react-router-dom';
 
 export const Completed = () => {
   const [item, setItem] = useState<Reservation>();
@@ -27,7 +26,7 @@ export const Completed = () => {
       setItem(newReservation);
     };
     fetchUser();
-  }, [data]);
+  }, [data, navigate]);
 
   return (
     <>

--- a/src/components/Reserve/Completed.tsx
+++ b/src/components/Reserve/Completed.tsx
@@ -17,6 +17,7 @@ export const Completed = () => {
     let id;
     const fetchUser = async () => {
       if (data === null) {
+        navigate('/login');
         return;
       }
       const tmp = JSON.parse(data);

--- a/src/components/Reserve/Completed.tsx
+++ b/src/components/Reserve/Completed.tsx
@@ -10,7 +10,6 @@ import { useParams } from 'react-router-dom';
 export const Completed = () => {
   const [item, setItem] = useState<Reservation>();
   const navigate = useNavigate();
-  // const { id } = useParams<{ id: string }>();
 
   let data = sessionStorage.getItem('auth');
 

--- a/src/components/Reserve/Reserve.tsx
+++ b/src/components/Reserve/Reserve.tsx
@@ -59,7 +59,7 @@ const Reserve = () => {
           >
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                <h1>設備予約</h1>
+                <h2 className={styles.title}>設備予約</h2>
               </Grid>
               <Grid item xs={12}>
                 <FormControl fullWidth>

--- a/src/components/Reserve/Reserve.tsx
+++ b/src/components/Reserve/Reserve.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import { FormControl, Grid, InputLabel, MenuItem, Select } from '@mui/material';
@@ -11,6 +11,7 @@ import ReserveDate from './ReserveDateTime';
 import ReserveBtn from './ReserveBtn';
 import styles from '../../styles/addReserve.module.css';
 import { Item } from '../../types/Item';
+import { useNavigate } from 'react-router-dom';
 
 const Reserve = () => {
   const [selectedItem, setSelectedItem] = useState('');
@@ -18,6 +19,14 @@ const Reserve = () => {
   const [itemDetailes, setItemDetailes] = useState<Item[]>();
   const dispatch = useDispatch();
   const addItems = useSelector(selectAdd);
+  const navigate = useNavigate();
+  const user = sessionStorage.getItem('auth');
+
+  useEffect(() => {
+    if (user === null) {
+      navigate('/login');
+    }
+  });
 
   async function fetchGetItems(item: string) {
     const items = await axios.get(

--- a/src/components/Reserve/ReserveBtn.tsx
+++ b/src/components/Reserve/ReserveBtn.tsx
@@ -7,7 +7,6 @@ import axios from 'axios';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 
-
 // エラーがaxiosに関するエラーか確かめる
 function isAxiosError(error: any): error is AxiosError {
   return !!error.isAxiosError;
@@ -37,7 +36,7 @@ const ReserveBtn = () => {
       );
       setUserId(user.id);
     }
-  }, []);
+  }, [data]);
 
   type addItem = {
     title: string;
@@ -72,19 +71,14 @@ const ReserveBtn = () => {
 
     try {
       await axios.post(`http://localhost:8000/reservations`, addItems);
-     
       const req = await axios.get(`http://localhost:8000/users/${userId}`);
-      const data = req.data
+      const data = req.data;
       const item = data.reservedItem;
       item.push(addItems);
       await axios.patch(`http://localhost:8000/users/${userId}`, {
         reservedItem: item,
       });
 
-      await axios.patch(`http://localhost:8000/users/${userId}`, {
-        reservedItem: item,
-      });
-      
       // addItemsの値をリセット
       dispatch(
         add({
@@ -95,16 +89,14 @@ const ReserveBtn = () => {
           endTime: '9:00',
           user: { id: 0, name: '' },
         }),
-        );
-        navigate(`/Completed`);
+      );
+      navigate(`/Completed`);
     } catch (e) {
       if (isAxiosError(e)) {
         setErr(e.response?.statusText);
       }
     }
   };
-
-
 
   return (
     <div>

--- a/src/components/Reserve/ReserveBtn.tsx
+++ b/src/components/Reserve/ReserveBtn.tsx
@@ -1,4 +1,4 @@
-import { Button, FormControl } from '@mui/material';
+import { Button } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import styles from '../../styles/addReserve.module.css';
 import { useSelector, useDispatch } from 'react-redux';
@@ -16,7 +16,6 @@ const ReserveBtn = () => {
   const [err, setErr] = useState<string | undefined>('');
   const [isFilledIn, setIsFilledIn] = useState(true);
   const [userId, setUserId] = useState(0);
-  const [successMsg, setSuccessMsg] = useState('');
 
   const addItems = useSelector(selectAdd);
   const dispatch = useDispatch();
@@ -101,7 +100,6 @@ const ReserveBtn = () => {
   return (
     <div>
       {err}
-      {successMsg}
       {isFilledIn || <p className={styles.center}>空欄箇所があります！</p>}
       <Button
         className={styles.btn}

--- a/src/components/Reserve/ReserveDateTime.tsx
+++ b/src/components/Reserve/ReserveDateTime.tsx
@@ -24,10 +24,12 @@ const ReserveDateTime = () => {
             value={value}
             onChange={(e) => {
               setValue(e.target.value);
+              // yyyy-mm-ddをyyyy/mm/ddに変換
+              const formatDate = e.target.value.replace(/-/g, `/`);
               dispatch(
                 add({
                   ...addItems,
-                  date: e.target.value,
+                  date: formatDate,
                 }),
               );
             }}

--- a/src/components/Top/ItemBox.tsx
+++ b/src/components/Top/ItemBox.tsx
@@ -20,7 +20,7 @@ const ItemBox = (item: Item) => {
       break;
   }
   return (
-    <Link to="/*">
+    <Link to={`/item/${item.id}`}>
       <Card>
         <img src={imageUrl} alt="" height={100} />
         <Typography component="p" variant="h5" fontWeight="bold">

--- a/src/styles/ItemPage.module.css
+++ b/src/styles/ItemPage.module.css
@@ -1,0 +1,38 @@
+/* タイトル関係 */
+.title {
+  font-size: 2.5rem;
+  text-align: center;
+  font-weight: bold;
+}
+.titleWrapper {
+  margin: 7rem 0;
+}
+
+/* ul, li関係 */
+ul {
+  list-style: none;
+  padding-inline-start: 0px;
+}
+.list {
+  display: flex;
+  font-size: 1.8rem;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  background-color: #fff;
+  justify-content: space-around;
+  border-radius: 10px;
+  box-shadow: 0 0 8px gray;
+}
+.listContent {
+  display: flex;
+  align-items: center;
+}
+
+.list p {
+  margin-right: 1rem;
+}
+
+/* 全体のwidthの設定 */
+.content {
+  width: 80%;
+}

--- a/src/styles/addReserve.module.css
+++ b/src/styles/addReserve.module.css
@@ -30,4 +30,5 @@
 
 .title {
   font-size: 2.5rem;
+  text-align: center;
 }


### PR DESCRIPTION
## やったこと
- ItemPageの追加
- 予約状況の表示
- cssの追加、他のページのcssの修正
- /src/components/Top/ItemBox.tsxの <Link to={`/item/${item.id}`}>に修正
- ログインしていない場合はloginページに飛ばす
### 予約がある場合
<img width="1470" alt="スクリーンショット 2023-04-19 19 35 45" src="https://user-images.githubusercontent.com/106084382/233049291-908a832c-304f-41de-a4b2-b85801e548b4.png">



### 予約がない場合
<img width="1470" alt="スクリーンショット 2023-04-19 11 25 53" src="https://user-images.githubusercontent.com/106084382/232950616-dc304441-a460-4c43-a80c-452385ec3d3f.png">

## やってないこと
- テスト