### PR TITLE
AddItemにバリデーション追加、AddItemテスト修正,

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { Completed } from './components/Reserve/Completed';
 import MyPage from './components/MyPage';
 import { ItemPage } from './components/Items/ItemPage';
 import Edit from './components/Reserve/Edit';
+import EditItem from './components/Management/EditItem';
 
 function App() {
   return (
@@ -30,6 +31,14 @@ function App() {
           element={
             <Suspense fallback={<p>Loading...</p>}>
               <Edit />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/editItem/:id"
+          element={
+            <Suspense fallback={<p>Loading...</p>}>
+              <EditItem />
             </Suspense>
           }
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Top from './components/Top/Top';
 import Header from './components/Header';
 import Login from './components/Login';
 import Register from './components/Register';
-import AddItem from './components/AddItem';
+import AddItem from './components/Management/AddItem';
 import Reserve from './components/Reserve/Reserve';
 import { Completed } from './components/Reserve/Completed';
 import MyPage from './components/MyPage';

--- a/src/components/Management/AddItem.tsx
+++ b/src/components/Management/AddItem.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useState } from 'react';
-import styles from '../styles/AddItem.module.css';
+import styles from '../../styles/AddItem.module.css';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -28,6 +28,7 @@ const MenuProps = {
 const AddItem = () => {
   const navigate = useNavigate();
   const [categoryName, setCategoryName] = useState<string>('');
+  const [errMsg, setErrMsg] = useState<string>('');
 
   const handleChange = (event: SelectChangeEvent<typeof categoryName>) => {
     const {
@@ -42,6 +43,14 @@ const AddItem = () => {
     const name = data.get('name')?.toString();
     const category = data.get('category')?.toString();
     if (!name || !category) return;
+
+    const res = await axios.get(`http://localhost:8000/items?name=${name}`);
+    const existingItems = res.data;
+    if (existingItems.length > 0) {
+      setErrMsg(`${name}は既に登録されています`);
+      return;
+    }
+
     await axios.post('http://localhost:8000/items', { name, category });
     navigate('/');
   };
@@ -66,6 +75,16 @@ const AddItem = () => {
         <Typography component="h1" variant="h5">
           設備を追加する
         </Typography>
+        {errMsg && (
+          <Typography
+            component="h1"
+            variant="h6"
+            sx={{ color: 'red', mt: 2 }}
+            data-testid="errMsg"
+          >
+            {errMsg}
+          </Typography>
+        )}
         <Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 3 }}>
           <Grid container spacing={2}>
             <Grid item xs={12}>

--- a/src/components/Management/EditItem.tsx
+++ b/src/components/Management/EditItem.tsx
@@ -1,0 +1,190 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import React, { FormEvent, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Button from '@mui/material/Button';
+import styles from '../../styles/AddItem.module.css';
+
+const categories = ['会議室', '社用車', 'PC'];
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
+const EditItem = () => {
+  const { id } = useParams();
+  const { data, refetch } = useQuery(['itemData'], () =>
+    axios.get(`http://localhost:8000/items/${id}`).then((res) => res.data),
+  );
+
+  const navigate = useNavigate();
+  const [name, setName] = useState<string>(data.name);
+  const [categoryName, setCategoryName] = useState<string>(data.category);
+  const [errMsg, setErrMsg] = useState<string>('');
+
+  const { mutate } = useMutation(
+    () =>
+      axios.patch(`http://localhost:8000/items/${id}`, {
+        name,
+        categoryName,
+      }),
+    {
+      onSuccess: () => {
+        refetch();
+        navigate('/');
+      },
+    },
+  );
+
+  const handleChange = (event: SelectChangeEvent<typeof categoryName>) => {
+    const {
+      target: { value },
+    } = event;
+    setCategoryName(value);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name || !categoryName) return;
+
+    const res = await axios.get(`http://localhost:8000/items?name=${name}`);
+    const existingItems = res.data;
+    if (existingItems.length > 0) {
+      setErrMsg(`${name}は既に登録されています`);
+      return;
+    }
+
+    mutate();
+    navigate('/');
+  };
+
+  const handleDelete = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await axios.delete(`http://localhost:8000/items?name=${name}`);
+  };
+
+  return (
+    <div className={styles.AddItem}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: 'white',
+          borderRadius: 10,
+          py: 0,
+          px: 4,
+          height: 450,
+          width: 500,
+          boxShadow: 10,
+        }}
+      >
+        <Typography component="h1" variant="h5">
+          設備を追加する
+        </Typography>
+        {errMsg && (
+          <Typography
+            component="h1"
+            variant="h6"
+            sx={{ color: 'red', mt: 2 }}
+            data-testid="errMsg"
+          >
+            {errMsg}
+          </Typography>
+        )}
+        <Box component="form" noValidate sx={{ mt: 3 }}>
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <TextField
+                required
+                fullWidth
+                id="name"
+                label="名前"
+                name="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl sx={{ width: 500 }} required>
+                <InputLabel id="category">タグ</InputLabel>
+                <Select
+                  data-testid="select"
+                  labelId="category"
+                  id="category"
+                  name="category"
+                  value={categoryName}
+                  onChange={handleChange}
+                  input={
+                    <OutlinedInput id="select-multiple-chip" label="Chip" />
+                  }
+                  MenuProps={MenuProps}
+                >
+                  {categories.map((category) => (
+                    <MenuItem key={category} value={category}>
+                      {category}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
+          <Grid container spacing={2}>
+            <Grid item xs={6}>
+              <Button
+                data-testid="postButton"
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{
+                  mt: 3,
+                  mb: 2,
+                  bgcolor: '#4970a3',
+                  ':hover': { background: '#3b5a84' },
+                }}
+                onClick={() => handleSubmit}
+              >
+                更新する
+              </Button>
+            </Grid>
+            <Grid item xs={6}>
+              <Button
+                data-testid="button"
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{
+                  mt: 3,
+                  mb: 2,
+                  bgcolor: 'orange',
+                  ':hover': { background: '#E48E00' },
+                }}
+                onClick={() => handleDelete}
+              >
+                削除する
+              </Button>
+            </Grid>
+          </Grid>
+        </Box>
+      </Box>
+    </div>
+  );
+};
+
+export default EditItem;

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -53,42 +53,40 @@ export default function MyPage() {
             <Box sx={{ mt: 3 }}>
               {reservations.map((reservation: Reservation) => {
                 return (
-                  <>
-                    <Box sx={{ width: 800 }}>
-                      <Typography
-                        variant="h4"
-                        sx={{
-                          mr: 1,
-                          border: 1,
-                          borderRadius: 5,
-                          paddingX: 4,
-                          marginY: 4,
-                        }}
-                      >
-                        <Grid container spacing={2} paddingY={4}>
-                          <Grid item xs={2.5}>
-                            {reservation.date}
-                          </Grid>
-                          <Grid item xs={3}>
-                            {reservation.startTime}~{reservation.endTime}
-                          </Grid>
-                          <Grid item xs={4.5}>
-                            {reservation.item.name}
-                          </Grid>
-                          <Grid item xs={2}>
-                            <Button
-                              fullWidth
-                              variant="contained"
-                              sx={{ fontSize: 16 }}
-                              onClick={() => clickHandler(reservation)}
-                            >
-                              編集
-                            </Button>
-                          </Grid>
+                  <Box sx={{ width: 800 }} key={reservation.id}>
+                    <Typography
+                      variant="h4"
+                      sx={{
+                        mr: 1,
+                        border: 1,
+                        borderRadius: 5,
+                        paddingX: 4,
+                        marginY: 4,
+                      }}
+                    >
+                      <Grid container spacing={2} paddingY={4}>
+                        <Grid item xs={2.5}>
+                          {reservation.date}
                         </Grid>
-                      </Typography>
-                    </Box>
-                  </>
+                        <Grid item xs={3}>
+                          {reservation.startTime}~{reservation.endTime}
+                        </Grid>
+                        <Grid item xs={4.5}>
+                          {reservation.item.name}
+                        </Grid>
+                        <Grid item xs={2}>
+                          <Button
+                            fullWidth
+                            variant="contained"
+                            sx={{ fontSize: 16 }}
+                            onClick={() => clickHandler(reservation)}
+                          >
+                            編集
+                          </Button>
+                        </Grid>
+                      </Grid>
+                    </Typography>
+                  </Box>
                 );
               })}
             </Box>

--- a/src/components/Reserve/ReserveBtn.tsx
+++ b/src/components/Reserve/ReserveBtn.tsx
@@ -75,8 +75,6 @@ const ReserveBtn = () => {
         `http://localhost:8000/reservations?userId=${userId}`,
       );
       const data = req.data;
-      // const item = data.reservedItem;
-      // item.push(addItems);
       const statusMsg = await axios.patch(
         `http://localhost:8000/users/${userId}`,
         {

--- a/src/components/Reserve/ReserveBtn.tsx
+++ b/src/components/Reserve/ReserveBtn.tsx
@@ -71,14 +71,16 @@ const ReserveBtn = () => {
 
     try {
       await axios.post(`http://localhost:8000/reservations`, addItems);
-      const req = await axios.get(`http://localhost:8000/users/${userId}`);
+      const req = await axios.get(
+        `http://localhost:8000/reservations?userId=${userId}`,
+      );
       const data = req.data;
-      const item = data.reservedItem;
-      item.push(addItems);
+      // const item = data.reservedItem;
+      // item.push(addItems);
       const statusMsg = await axios.patch(
         `http://localhost:8000/users/${userId}`,
         {
-          reservedItem: item,
+          reservedItem: data,
         },
       );
       // ユーザーのreservedItemを更新できたらsuccessの状態を更新する（テストのため）

--- a/src/tests/AddItem.test.tsx
+++ b/src/tests/AddItem.test.tsx
@@ -1,41 +1,30 @@
 import React from 'react';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
 import {
-  cleanup,
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from '@testing-library/react';
-import AddItem from '../components/AddItem';
+import AddItem from '../components/Management/AddItem';
 import userEvent from '@testing-library/user-event';
+import axios from 'axios';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const handlers = [
-  rest.post('http://localhost:8000/Items', (req, res, ctx) => {
-    return res(ctx.status(200));
-  }),
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+const itemsMock: [] = [];
+const existingItemsMock = [
+  {
+    name: '大会議室',
+    category: '会議室',
+    id: 1,
+  },
 ];
-
-const server = setupServer(...handlers);
-
-beforeAll(() => {
-  server.listen();
-});
-
-afterEach(() => {
-  server.resetHandlers();
-  cleanup();
-});
-
-afterAll(() => {
-  server.close();
-});
 
 describe('AddItem', () => {
   it('1 Should render all the elements correctly', () => {
@@ -51,6 +40,7 @@ describe('AddItem', () => {
 
   it('2 Should add item and navigate top', async () => {
     render(<AddItem />);
+    axiosMock.get.mockResolvedValue({ data: itemsMock });
     const inputValue = screen.getByRole('textbox');
     await userEvent.type(inputValue, 'ウィンドウズ');
     const selectCompoEl = screen.getByTestId('select');
@@ -65,11 +55,51 @@ describe('AddItem', () => {
     fireEvent.click(options[2]);
     expect(button).toHaveTextContent('PC');
     await userEvent.click(screen.getByTestId('button'));
+    await waitFor(() =>
+      expect(axiosMock.get).toHaveBeenCalledWith(
+        'http://localhost:8000/items?name=ウィンドウズ',
+      ),
+    );
+    await waitFor(() =>
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        'http://localhost:8000/items',
+        {
+          category: 'PC',
+          name: 'ウィンドウズ',
+        },
+      ),
+    );
     expect(mockNavigate).toBeCalledWith('/');
     expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it('3 Should return if input is empty', async () => {
+  it('3 Should return if name is already existing', async () => {
+    render(<AddItem />);
+    axiosMock.get.mockResolvedValue({ data: existingItemsMock });
+    const inputValue = screen.getByRole('textbox');
+    await userEvent.type(inputValue, '大会議室');
+    const selectCompoEl = screen.getByTestId('select');
+    const button = within(selectCompoEl).getByRole(
+      'button',
+    ) as HTMLInputElement;
+    fireEvent.mouseDown(button);
+    const listbox = within(screen.getByRole('presentation')).getByRole(
+      'listbox',
+    );
+    const options = within(listbox).getAllByRole('option');
+    fireEvent.click(options[0]);
+    expect(button).toHaveTextContent('会議室');
+    await userEvent.click(screen.getByTestId('button'));
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      'http://localhost:8000/items?name=大会議室',
+    );
+    expect(
+      screen.getByText('大会議室は既に登録されています'),
+    ).toBeInTheDocument();
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
+  });
+
+  it('4 Should return if input is empty', async () => {
     render(<AddItem />);
     await userEvent.click(screen.getByTestId('button'));
     expect(mockNavigate).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
## やったこと
### AddItemにバリデーション追加、AddItemテスト修正
- 設備登録時に名前が重複しないようバリデーション追加
- 変更に伴うテスト修正
### EditItem実装
- 既に登録してある設備の編集、削除機能を実装
- 今のところパスの直打ちでしかアクセスできない仕様（対応予定）
- パスは/editItem/${itemId}
### 予約編集時と削除時のバグ修正
- 金曜日にみほちゃんが相談してくれた連続して予約を編集しようとすると古いデータがフォームに入力されているバグの修正
- 予約削除時にusersテーブルのredervedItemからの削除ができていなかったので修正。
- 上記修正に伴い予約登録時にusersテーブルにpatchするデータの取り方を変更。
- MypageとEditコンポーネントのコンソールに出ていたwarning解消。

### 予約編集時のバグの原因
参考記事
https://zenn.dev/t_keshi/articles/react-query-prescription#cache-is-%E4%BD%95%EF%BC%9F

こちらによると、「ReactQueryはAPIから返ってきたデータをしばらくの間、Cacheという場所に保持してくれる機能を持っています。同じリクエストをしたときには、Cacheに保持していたデータを取り出して使うことができます。」
とあり、恐らくこちらが働いていた模様。
今回はデータを更新したいので、新しいデータを取ってくるよう指示を追加しました。
解決方法も記事の中に記載あり。


## やっていないこと
- 未ログイン時にログイン画面に飛ばす処理