### PR TITLE
Completed.test.tsxの実装

### DIFF
--- a/src/components/Reserve/Completed.tsx
+++ b/src/components/Reserve/Completed.tsx
@@ -7,8 +7,8 @@ import axios from 'axios';
 import { Reservation } from '../../types/Reservation';
 
 export const Completed = () => {
-  const [item, setItem] = useState<Reservation>();
-  const [errorMsg, setErrorMsg] = useState('');
+  const [newReservation, setNewRservation] = useState<Reservation>();
+  const [errorMsg, setErrorMsg] = useState(false);
   const navigate = useNavigate();
 
   let data = sessionStorage.getItem('auth');
@@ -20,19 +20,22 @@ export const Completed = () => {
         navigate('/login');
         return;
       }
-      const tmp = JSON.parse(data);
-      userId = tmp.id;
-      const result = await axios.get(`http://localhost:8000/users/${userId}`);
+      try {
+        const tmp = JSON.parse(data);
+        userId = tmp.id;
+        const result = await axios.get(`http://localhost:8000/users/${userId}`);
 
-      if (result.data.reservedItem.length > 0) {
-        let newReservation = await result.data.reservedItem.slice(-1)[0];
-        newReservation = {
-          ...newReservation,
-          date: newReservation.date.replace(/-/g, `/`),
-        };
-        setItem(newReservation);
-      } else {
-        return setErrorMsg('Fetch Failed');
+        if (result.data.reservedItem.length > 0) {
+          let newReservation = await result.data.reservedItem.slice(-1)[0];
+          newReservation = {
+            ...newReservation,
+            // yyyy-mm-ddをyyyy/mm/ddに変換
+            date: newReservation.date.replace(/-/g, `/`),
+          };
+          setNewRservation(newReservation);
+        }
+      } catch (e) {
+        setErrorMsg(true);
       }
     };
     fetchLatestReservation();
@@ -40,24 +43,13 @@ export const Completed = () => {
 
   return (
     <>
-      {errorMsg}
-      <div className={styles.boxWrapper}>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'white',
-            borderRadius: 10,
-            py: 0,
-            px: 4,
-            height: 550,
-            width: 600,
-            boxShadow: 10,
-          }}
-        >
-          <h2 className={styles.title}>以下の予約が完了しました！</h2>
+      {errorMsg ? (
+        <div className={styles.error}>
+          <p data-testid="errorMsg">Fetch Failed</p>
+          <p>通信エラーです。時間を置いて再度お試しください。</p>
+        </div>
+      ) : (
+        <div className={styles.boxWrapper}>
           <Box
             sx={{
               display: 'flex',
@@ -68,40 +60,57 @@ export const Completed = () => {
               borderRadius: 10,
               py: 0,
               px: 4,
-              height: 400,
-              width: 400,
-              border: 1,
-              borderColor: '#999',
+              height: 550,
+              width: 600,
+              boxShadow: 10,
             }}
           >
-            <div className={styles.item}>
-              <p>タイトル：{item?.title}</p>
-              <p>設備：{item?.item.name}</p>
-              <p>日付：{item?.date}</p>
-              <p>開始時刻：{item?.startTime}</p>
-              <p>終了時刻：{item?.endTime}</p>
-              <p>ユーザー：{item?.user.name}</p>
-            </div>
+            <h2 className={styles.title}>以下の予約が完了しました！</h2>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: 'white',
+                borderRadius: 10,
+                py: 0,
+                px: 4,
+                height: 400,
+                width: 400,
+                border: 1,
+                borderColor: '#999',
+              }}
+            >
+              <div className={styles.item}>
+                <p>タイトル：{newReservation?.title}</p>
+                <p>設備：{newReservation?.item.name}</p>
+                <p>日付：{newReservation?.date}</p>
+                <p>開始時刻：{newReservation?.startTime}</p>
+                <p>終了時刻：{newReservation?.endTime}</p>
+                <p>ユーザー：{newReservation?.user.name}</p>
+              </div>
+            </Box>
+            <Button
+              className={styles.btn}
+              data-testid="button"
+              type="submit"
+              variant="contained"
+              sx={{
+                mt: 3,
+                mb: 2,
+                width: 200,
+                fontSize: 16,
+                bgcolor: '#4970a3',
+                ':hover': { background: '#3b5a84' },
+              }}
+              onClick={() => navigate('/reserve')}
+            >
+              続けて登録する
+            </Button>
           </Box>
-          <Button
-            className={styles.btn}
-            data-testid="button"
-            type="submit"
-            variant="contained"
-            sx={{
-              mt: 3,
-              mb: 2,
-              width: 200,
-              fontSize: 16,
-              bgcolor: '#4970a3',
-              ':hover': { background: '#3b5a84' },
-            }}
-            onClick={() => navigate('/reserve')}
-          >
-            続けて登録する
-          </Button>
-        </Box>
-      </div>
+        </div>
+      )}
     </>
   );
 };

--- a/src/styles/addReserve.module.css
+++ b/src/styles/addReserve.module.css
@@ -32,3 +32,8 @@
   font-size: 2.5rem;
   text-align: center;
 }
+
+.error {
+  font-size: 3rem;
+  text-align: center;
+}

--- a/src/tests/Completed.test.tsx
+++ b/src/tests/Completed.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { Completed } from '../components/Reserve/Completed';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+function getUserInfo() {
+  const userInfo = window.sessionStorage.getItem('auth');
+  if (userInfo) {
+    return JSON.parse(userInfo);
+  }
+  return {};
+}
+
+type StoreType = {
+  [key: string]: string;
+};
+
+const sessionStorageMock = (() => {
+  let store: StoreType = {};
+
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  // 上書き可能にするため
+  writable: true,
+});
+
+const handlers = [
+  rest.get('http://localhost:8000/users/1', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        name: 'モジャ',
+        email: 'test1@example.com',
+        password: 'password',
+        reservedItem: [
+          {
+            title: 'test1',
+            item: {
+              id: 23,
+              name: 'トヨタ・ハイエースバン',
+            },
+            date: '2023-04-19',
+            startTime: '9:00',
+            endTime: '9:00',
+            user: {
+              id: 2,
+              name: 'test',
+            },
+            id: 1,
+          },
+          {
+            title: 'sample',
+            item: {
+              id: 2,
+              name: '社用車1',
+            },
+            date: '2023-04-20',
+            startTime: '10:00',
+            endTime: '11:00',
+            user: {
+              id: 2,
+              name: 'test',
+            },
+            id: 2,
+          },
+        ],
+        id: 1,
+      }),
+    );
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+beforeEach(() => {
+  window.sessionStorage.setItem(
+    'auth',
+    JSON.stringify({ id: 1, name: 'test' }),
+  );
+  jest.restoreAllMocks();
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe('Completed component Test Cases', () => {
+  it('should setItem correctly of sessionStorage', () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, 'getItem');
+    const actualValue = getUserInfo();
+    expect(actualValue).toEqual({ id: 1, name: 'test' });
+    expect(getItemSpy).toBeCalledWith('auth');
+  });
+
+  it('should render the new reserved item correctlly', async () => {
+    render(<Completed />);
+    expect(screen.queryByText('タイトル：sample')).toBeNull();
+    expect(screen.queryByText('設備：社用車1')).toBeNull();
+    expect(screen.queryByText('日付：2023/04/20')).toBeNull();
+    expect(screen.queryByText('開始時刻：10:00')).toBeNull();
+    expect(screen.queryByText('終了時刻：11:00')).toBeNull();
+    expect(screen.queryByText('ユーザー：test')).toBeNull();
+    expect(screen.getByText('以下の予約が完了しました！')).toBeInTheDocument();
+    expect(await screen.findByText('タイトル：sample')).toBeInTheDocument();
+    expect(screen.getByText('設備：社用車1')).toBeInTheDocument();
+    expect(screen.getByText('日付：2023/04/20')).toBeInTheDocument();
+    expect(screen.getByText('開始時刻：10:00')).toBeInTheDocument();
+    expect(screen.getByText('終了時刻：11:00')).toBeInTheDocument();
+    expect(screen.getByText('ユーザー：test')).toBeInTheDocument();
+  });
+
+  it('should call useNavigate Mock when button clicked', async () => {
+    render(<Completed />);
+    const button = screen.getByTestId('button');
+    await userEvent.click(button);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith('/reserve');
+  });
+
+  it('sshould not render list of the added reservation when fetch failed', async () => {
+    server.use(
+      rest.get('http://localhost:8000/users/1', (req, res, ctx) => {
+        return res(ctx.status(404));
+      }),
+    );
+    render(<Completed />);
+    expect(screen.queryByText('タイトル：sample')).toBeNull();
+    expect(screen.queryByText('設備：社用車1')).toBeNull();
+    expect(screen.queryByText('日付：2023/04/20')).toBeNull();
+    expect(screen.queryByText('開始時刻：10:00')).toBeNull();
+    expect(screen.queryByText('終了時刻：11:00')).toBeNull();
+    expect(screen.queryByText('ユーザー：test')).toBeNull();
+    expect(await screen.findByTestId('errorMsg')).toBeTruthy();
+    expect(await screen.findByText('Fetch Failed')).toBeInTheDocument();
+    expect(screen.queryByText('タイトル：sample')).toBeNull();
+    expect(screen.queryByText('設備：社用車1')).toBeNull();
+    expect(screen.queryByText('日付：2023/04/20')).toBeNull();
+    expect(screen.queryByText('開始時刻：10:00')).toBeNull();
+    expect(screen.queryByText('終了時刻：11:00')).toBeNull();
+    expect(screen.queryByText('ユーザー：test')).toBeNull();
+  });
+});

--- a/src/tests/Completed.test.tsx
+++ b/src/tests/Completed.test.tsx
@@ -48,7 +48,7 @@ const handlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        name: 'モジャ',
+        name: 'test',
         email: 'test1@example.com',
         password: 'password',
         reservedItem: [


### PR DESCRIPTION
## やったこと
- Completed.test.tsxの実装
<img width="1470" alt="スクリーンショット 2023-04-24 15 11 06" src="https://user-images.githubusercontent.com/106084382/233919253-5ec6fc55-fd80-4896-9af2-88ed17f33ff2.png">

- テストに伴って、Completed.tsxの修正
- CSSの追加
- fetch失敗した時の表示を追加(テストで使用したいため)
<img width="1470" alt="スクリーンショット 2023-04-24 15 10 21" src="https://user-images.githubusercontent.com/106084382/233919273-5824ac20-6937-45c9-b28e-01980a125043.png">

###  SessionStorage関連で追記した箇所 @Completed.test.tsx
1. sessionStorageを毎テストごとに設定するのに、beforeEachの中で```jest.restoreAllMocks();```を記述して、一旦リストアしないと使いまわせないみたいです。
 - [参考にした記事](https://stackoverflow.com/questions/51566816/what-is-the-best-way-to-mock-window-sessionstorage-in-jest)
 - [公式](https://jestjs.io/ja/docs/jest-object#jestrestoreallmocks)
 
2. Object.defineProperty()を使用する際```writable: true,```を記述しないと上書きができず、テスト毎にbeforeEach内のsessionStorage.setItem()を使用するため記述しています。
 - [公式](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)
 - [参考にした記事](https://note.affi-sapo-sv.com/js-defineproperty.php)