### PR TITLE
認証テストの実装

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -65,6 +65,7 @@ export default function Login() {
                 margin="normal"
                 required
                 fullWidth
+                data-testid="input-email"
                 id="email"
                 label="Email Address"
                 name="email"
@@ -79,6 +80,7 @@ export default function Login() {
                 name="password"
                 label="Password"
                 type="password"
+                data-testid="input-password"
                 id="password"
                 autoComplete="current-password"
                 onChange={(e) => setPassword(e.target.value)}
@@ -87,6 +89,7 @@ export default function Login() {
                 type="submit"
                 fullWidth
                 variant="contained"
+                data-testid="button"
                 sx={{ mt: 3, mb: 2 }}
               >
                 ログイン

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -17,17 +17,20 @@ export default function Login() {
   const dispatch = useDispatch<AppDispatch>();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!email || !password) {
+      setErrorMsg('未入力の項目があります');
+      return;
+    }
     const result = await dispatch(
       fetchAsyncLogin({ email: email, password: password }),
     );
     if (fetchAsyncLogin.fulfilled.match(result)) {
       navigate('/');
-    } else {
-      return;
     }
   };
 
@@ -55,6 +58,9 @@ export default function Login() {
             <Typography component="h1" variant="h5">
               Login
             </Typography>
+            <Typography component="h2" variant="h6">
+              {errorMsg}
+            </Typography>
             <Box
               component="form"
               noValidate
@@ -66,6 +72,7 @@ export default function Login() {
                 required
                 fullWidth
                 data-testid="input-email"
+                placeholder="user-email"
                 id="email"
                 label="Email Address"
                 name="email"
@@ -81,6 +88,7 @@ export default function Login() {
                 label="Password"
                 type="password"
                 data-testid="input-password"
+                placeholder="user-password"
                 id="password"
                 autoComplete="current-password"
                 onChange={(e) => setPassword(e.target.value)}

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -19,13 +19,14 @@ export default function Register() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // if (!name || !email || !password) {
-    //   alert('未入力の項目があります');
-    //   return;
-    // }
+    if (!name || !email || !password) {
+      setErrorMsg('未入力の項目があります');
+      return;
+    }
     const result = await dispatch(
       fetchAsyncRegister({
         name: name,
@@ -36,8 +37,6 @@ export default function Register() {
     );
     if (fetchAsyncRegister.fulfilled.match(result)) {
       navigate('/login');
-    } else {
-      return;
     }
   };
 
@@ -65,6 +64,9 @@ export default function Register() {
             <Typography component="h1" variant="h5">
               Register
             </Typography>
+            <Typography component="h2" variant="h6">
+              {errorMsg}
+            </Typography>
             <Box
               component="form"
               noValidate
@@ -79,6 +81,7 @@ export default function Register() {
                     required
                     fullWidth
                     data-testid="input-name"
+                    placeholder="user-name"
                     id="name"
                     label="Name"
                     autoFocus
@@ -90,6 +93,7 @@ export default function Register() {
                     required
                     fullWidth
                     data-testid="input-email"
+                    placeholder="user-email"
                     id="email"
                     label="Email Address"
                     name="email"
@@ -105,6 +109,7 @@ export default function Register() {
                     label="Password"
                     type="password"
                     data-testid="input-password"
+                    placeholder="user-password"
                     id="password"
                     autoComplete="new-password"
                     onChange={(e) => setPassword(e.target.value)}

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -22,10 +22,10 @@ export default function Register() {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!name || !email || !password) {
-      alert('未入力の項目があります');
-      return;
-    }
+    // if (!name || !email || !password) {
+    //   alert('未入力の項目があります');
+    //   return;
+    // }
     const result = await dispatch(
       fetchAsyncRegister({
         name: name,
@@ -78,6 +78,7 @@ export default function Register() {
                     name="name"
                     required
                     fullWidth
+                    data-testid="input-name"
                     id="name"
                     label="Name"
                     autoFocus
@@ -88,6 +89,7 @@ export default function Register() {
                   <TextField
                     required
                     fullWidth
+                    data-testid="input-email"
                     id="email"
                     label="Email Address"
                     name="email"
@@ -102,6 +104,7 @@ export default function Register() {
                     name="password"
                     label="Password"
                     type="password"
+                    data-testid="input-password"
                     id="password"
                     autoComplete="new-password"
                     onChange={(e) => setPassword(e.target.value)}
@@ -112,6 +115,7 @@ export default function Register() {
                 type="submit"
                 fullWidth
                 variant="contained"
+                data-testid="button"
                 sx={{ mt: 3, mb: 2 }}
               >
                 ユーザー登録

--- a/src/features/authSlice.ts
+++ b/src/features/authSlice.ts
@@ -48,7 +48,7 @@ export const authSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchAsyncLogin.fulfilled, (state, action) => {
       if (!action.payload[0]) {
-        alert('ログインに失敗しました');
+        return;
       } else {
         const obj = {
           id: action.payload[0].id,

--- a/src/tests/Auth.test.js
+++ b/src/tests/Auth.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from '../features/authSlice';
+import Register from '../components/Register';
+import Login from '../components/Login';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const handlers = [
+  rest.post('http://localhost:8000/users/', (req, res, ctx) => {
+    return res(ctx.status(201));
+  }),
+  rest.get('http://localhost:8000/users/1', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({ id: 1, name: 'Momo' }));
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe('Auth Component Test Cases', () => {
+  let store;
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        auth: authReducer,
+      },
+    });
+  });
+  it('1-1: should render all the elements correctly in Register Component', async () => {
+    render(
+      <Provider store={store}>
+        <Register />
+      </Provider>,
+    );
+    expect(screen.getByTestId('input-name')).toBeTruthy();
+    expect(screen.getByTestId('input-email')).toBeTruthy();
+    expect(screen.getByTestId('input-password')).toBeTruthy();
+    expect(screen.getByTestId('button')).toBeTruthy();
+  });
+  it('1-2: Should route to LoginPage when registeration is successful', async () => {
+    render(
+      <Provider store={store}>
+        <Register />
+      </Provider>,
+    );
+    await userEvent.click(screen.getByTestId('button'));
+    // await userEvent.click(screen.getByText('ユーザー登録'));
+    expect(mockNavigate).toBeCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+  it('2-1 should render all the elements correctly in Login Component', async () => {
+    render(
+      <Provider store={store}>
+        <Login />
+      </Provider>,
+    );
+    expect(screen.getByTestId('input-email')).toBeTruthy();
+    expect(screen.getByTestId('input-password')).toBeTruthy();
+    expect(screen.getByTestId('button')).toBeTruthy();
+  });
+});

--- a/src/tests/Auth.test.js
+++ b/src/tests/Auth.test.js
@@ -18,19 +18,25 @@ const handlers = [
   rest.post('http://localhost:8000/users/', (req, res, ctx) => {
     return res(ctx.status(201), ctx.json({ id: 3, name: 'Sakamoto' }));
   }),
-  rest.get('http://localhost:8000/users/', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          id: 1,
-          name: 'Murakami',
-          email: 'maito@example.com',
-          password: '1111',
-        },
-        { id: 2, name: 'Hirai', email: 'a@example.com', password: '1111' },
-      ]),
-    );
+  rest.get(`http://localhost:8000/users/`, (req, res, ctx) => {
+    const query = req.url.searchParams;
+    const email = query.get('email');
+    const password = query.get('password');
+    if (email === 'maito@example.com') {
+      if (password === '1111') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              id: 1,
+              name: 'Murakami',
+              email: 'maito@example.com',
+              password: '1111',
+            },
+          ]),
+        );
+      }
+    }
   }),
 ];
 

--- a/src/tests/Auth.test.js
+++ b/src/tests/Auth.test.js
@@ -22,20 +22,18 @@ const handlers = [
     const query = req.url.searchParams;
     const email = query.get('email');
     const password = query.get('password');
-    if (email === 'maito@example.com') {
-      if (password === '1111') {
-        return res(
-          ctx.status(200),
-          ctx.json([
-            {
-              id: 1,
-              name: 'Murakami',
-              email: 'maito@example.com',
-              password: '1111',
-            },
-          ]),
-        );
-      }
+    if (email === 'maito@example.com' && password === '1111') {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          {
+            id: 1,
+            name: 'Murakami',
+            email: 'maito@example.com',
+            password: '1111',
+          },
+        ]),
+      );
     }
   }),
 ];

--- a/src/tests/Auth.test.js
+++ b/src/tests/Auth.test.js
@@ -16,10 +16,21 @@ jest.mock('react-router-dom', () => ({
 
 const handlers = [
   rest.post('http://localhost:8000/users/', (req, res, ctx) => {
-    return res(ctx.status(201));
+    return res(ctx.status(201), ctx.json({ id: 3, name: 'Sakamoto' }));
   }),
-  rest.get('http://localhost:8000/users/1', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1, name: 'Momo' }));
+  rest.get('http://localhost:8000/users/', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json([
+        {
+          id: 1,
+          name: 'Murakami',
+          email: 'maito@example.com',
+          password: '1111',
+        },
+        { id: 2, name: 'Hirai', email: 'a@example.com', password: '1111' },
+      ]),
+    );
   }),
 ];
 
@@ -62,10 +73,24 @@ describe('Auth Component Test Cases', () => {
         <Register />
       </Provider>,
     );
+    const inputValueName = screen.getByPlaceholderText('user-name');
+    await userEvent.type(inputValueName, 'Sakamoto');
+    const inputValueEmail = screen.getByPlaceholderText('user-email');
+    await userEvent.type(inputValueEmail, 'a@example.com');
+    const inputValuePass = screen.getByPlaceholderText('user-password');
+    await userEvent.type(inputValuePass, '1111');
     await userEvent.click(screen.getByTestId('button'));
-    // await userEvent.click(screen.getByText('ユーザー登録'));
     expect(mockNavigate).toBeCalledWith('/login');
     expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+  it('1-3: Should not route to LoginPage when registeration is rejected', async () => {
+    render(
+      <Provider store={store}>
+        <Register />
+      </Provider>,
+    );
+    await userEvent.click(screen.getByTestId('button'));
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
   });
   it('2-1 should render all the elements correctly in Login Component', async () => {
     render(
@@ -76,5 +101,28 @@ describe('Auth Component Test Cases', () => {
     expect(screen.getByTestId('input-email')).toBeTruthy();
     expect(screen.getByTestId('input-password')).toBeTruthy();
     expect(screen.getByTestId('button')).toBeTruthy();
+  });
+  it('2-2: Should route to TopPage when login is successful', async () => {
+    render(
+      <Provider store={store}>
+        <Login />
+      </Provider>,
+    );
+    const inputValueEmail = screen.getByPlaceholderText('user-email');
+    await userEvent.type(inputValueEmail, 'maito@example.com');
+    const inputValuePass = screen.getByPlaceholderText('user-password');
+    await userEvent.type(inputValuePass, '1111');
+    await userEvent.click(screen.getByTestId('button'));
+    expect(mockNavigate).toBeCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+  it('1-3: Should not route to TopPage when login is rejected', async () => {
+    render(
+      <Provider store={store}>
+        <Login />
+      </Provider>,
+    );
+    await userEvent.click(screen.getByTestId('button'));
+    expect(mockNavigate).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/Auth.test.js
+++ b/src/tests/Auth.test.js
@@ -116,7 +116,7 @@ describe('Auth Component Test Cases', () => {
     expect(mockNavigate).toBeCalledWith('/');
     expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
-  it('1-3: Should not route to TopPage when login is rejected', async () => {
+  it('2-3: Should not route to TopPage when login is rejected', async () => {
     render(
       <Provider store={store}>
         <Login />


### PR DESCRIPTION
## やったこと
- コンポーネントの要素がレンダリングされているか
- 登録、ログイン成功時にnavigateで遷移が行われるか
- 登録、ログイン失敗時に遷移が行われないか
- 今までalertでエラーを表示させていたのをやめて、msgで出すように変更

## やってないこと
- authSliceのテスト

## カバレッジ率
<img width="593" alt="スクリーンショット 2023-04-25 10 22 46" src="https://user-images.githubusercontent.com/114968506/234152877-1a79890a-78f3-4f00-b2b7-2f237bf3df72.png">

## 検討
- カバレッジ率はまだ低いところがあるから、他のテストやって時間が余りそうだったら戻ってきたい…という感じです。一旦認証関連のテストは終わりにしようと思ってます。
