### PR TITLE
ItemPage.test.tsxの実装、testで使用しているsessionStorageのリファクタリング

### DIFF
--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -7,7 +7,7 @@ import Button from '@mui/material/Button';
 import { useNavigate } from 'react-router-dom';
 
 const ItemPage = () => {
-  const [item, setItem] = useState<Reservation[]>([]);
+  const [items, setItems] = useState<Reservation[]>([]);
   const [isEmpty, setIsEmpty] = useState(false);
   const { id } = useParams();
   const navigate = useNavigate();
@@ -32,7 +32,7 @@ const ItemPage = () => {
             date: item.date.replace(/-/g, `/`),
           };
         });
-        setItem(reservations);
+        setItems(reservations);
       }
     };
     fetchItem();
@@ -50,7 +50,7 @@ const ItemPage = () => {
         </div>
         <div>
           <ul>
-            {item?.map((item) => (
+            {items?.map((item) => (
               <li key={item.id} className={styles.list}>
                 <div className={styles.listContent}>
                   <p>{item.title}</p>

--- a/src/components/Items/ItemPage.tsx
+++ b/src/components/Items/ItemPage.tsx
@@ -21,9 +21,10 @@ const ItemPage = () => {
       const result = await axios.get(
         `http://localhost:8000/reservations?item.id=${id}`,
       );
+
       if (!result.data.length) {
         setIsEmpty(true);
-      } else {
+      } else if (result.data.length > 0) {
         let reservations = result.data;
         reservations = reservations.map((item: Reservation) => {
           return {
@@ -66,7 +67,7 @@ const ItemPage = () => {
                 <div>
                   <Button
                     className={styles.btn}
-                    data-testid="btn-nav"
+                    data-testid={`btn-nav-${item.id}`}
                     type="submit"
                     variant="contained"
                     sx={{
@@ -77,7 +78,7 @@ const ItemPage = () => {
                       width: 150,
                       ':hover': { background: '#3b5a84' },
                     }}
-                    onClick={() => navigate(`/${item.id}`)}
+                    onClick={() => navigate(`/reserve/edit/${item.id}`)}
                   >
                     修正・削除
                   </Button>

--- a/src/tests/Completed.test.tsx
+++ b/src/tests/Completed.test.tsx
@@ -3,43 +3,18 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { Completed } from '../components/Reserve/Completed';
+import { getUserInfo, sessionStorageMock } from './sessionStorage';
 
+// useNavigateのMock
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-function getUserInfo() {
-  const userInfo = window.sessionStorage.getItem('auth');
-  if (userInfo) {
-    return JSON.parse(userInfo);
-  }
-  return {};
-}
-
-type StoreType = {
-  [key: string]: string;
-};
-
-const sessionStorageMock = (() => {
-  let store: StoreType = {};
-
-  return {
-    getItem(key: string) {
-      return store[key] || null;
-    },
-    setItem(key: string, value: string) {
-      store[key] = value.toString();
-    },
-    clear() {
-      store = {};
-    },
-  };
-})();
-
+// windowオブジェクトのsessionStorageをsessionStorageMockプロパティに変更
 Object.defineProperty(window, 'sessionStorage', {
   value: sessionStorageMock,
-  // 上書き可能にするため
+  // 書き込み可能にするため
   writable: true,
 });
 

--- a/src/tests/ItemPage.test.tsx
+++ b/src/tests/ItemPage.test.tsx
@@ -2,32 +2,29 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { Router } from 'react-router-dom';
+import Router from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { getUserInfo, sessionStorageMock } from './sessionStorage';
 import ItemPage from '../components/Items/ItemPage';
-import { MemoryRouter, Route } from 'react-router-dom';
 
 const mockNavigate = jest.fn();
-// jest.mock('react-router-dom', () => ({
-//   useNavigate: () => mockNavigate,
-// }));
 
-const mockUseParams = jest.fn();
-jest.mock('react-router-dom', () => {
-  return {
-    useParams: () => ({
-      id: '1',
-    }),
-    useNavigate: () => mockNavigate,
-  };
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+// windowオブジェクトのsessionStorageをsessionStorageMockプロパティに変更
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
 });
 
 const server = setupServer(
   rest.get(`http://localhost:8000/reservations/`, (req, res, ctx) => {
     const query = req.url.searchParams;
-    console.log(query);
-    const item = query.get('item.id');
-    console.log(item);
-    if (item === '1') {
+    const itemId = query.get('item.id');
+    if (itemId === '1') {
       return res(
         ctx.status(200),
         ctx.json([
@@ -39,7 +36,7 @@ const server = setupServer(
             },
             date: '2023-04-19',
             startTime: '9:00',
-            endTime: '9:00',
+            endTime: '10:00',
             user: {
               id: 1,
               name: 'test',
@@ -52,12 +49,12 @@ const server = setupServer(
               id: 1,
               name: '大会議室',
             },
-            date: '2023-04-19',
-            startTime: '9:00',
-            endTime: '9:00',
+            date: '2023-04-20',
+            startTime: '10:00',
+            endTime: '11:00',
             user: {
               id: 2,
-              name: 'モジャ',
+              name: 'test',
             },
             id: 5,
           },
@@ -70,6 +67,14 @@ const server = setupServer(
 beforeAll(() => {
   server.listen();
 });
+beforeEach(() => {
+  window.sessionStorage.setItem(
+    'auth',
+    JSON.stringify({ id: 1, name: 'test' }),
+  );
+  jest.restoreAllMocks();
+  jest.spyOn(Router, 'useNavigate').mockImplementation(() => mockNavigate)
+});
 afterEach(() => {
   server.resetHandlers();
 });
@@ -78,20 +83,68 @@ afterAll(() => {
 });
 
 describe('ItemPage component Test', () => {
-  it('render the reservedItem', async () => {
-    const id = 1;
-    // render(
-    //   <MemoryRouter initialEntries={[`/item/${id}`]}>
-    //     <Route path="/user/:id">
-    //       <ItemPage />
-    //     </Route>
-    //   </MemoryRouter>,
-    // );
-    // expect(mockUseParams).toHaveBeenCalledTimes(1);
-    // expect(
-    //   screen.getByText('予約状況は以下のようになっています'),
-    // ).toBeInTheDocument();
-    // expect(screen.queryByText('test1')).toBeNull();
-    // expect(await screen.findByText('test1')).toBeInTheDocument();
+  it('should get UserInfo from sessionStorage', () => {
+    const getItemSpy = jest.spyOn(window.sessionStorage, 'getItem');
+    const actualValue = getUserInfo();
+    expect(actualValue).toEqual({ id: 1, name: 'test' });
+    expect(getItemSpy).toBeCalledWith('auth');
+  });
+  it('should render the ItemPage', async () => {
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '1' });
+    render(
+      <MemoryRouter initialEntries={[`/item/:id`]}>
+        <ItemPage />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByText('予約状況は以下のようになっています'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('test1')).toBeInTheDocument();
+    expect(screen.getAllByText('大会議室')[0]).toBeInTheDocument();
+    expect(screen.getByText('2023/04/19')).toBeInTheDocument();
+    expect(screen.getByText('9:00~10:00')).toBeInTheDocument();
+    expect(screen.getByTestId('btn-nav-1')).toBeTruthy();
+    expect(await screen.findByText('test2')).toBeInTheDocument();
+    expect(screen.getAllByText('大会議室')[1]).toBeInTheDocument();
+    expect(screen.getByText('2023/04/20')).toBeInTheDocument();
+    expect(screen.getByText('10:00~11:00')).toBeInTheDocument();
+    expect(screen.getByTestId('btn-nav-5')).toBeTruthy();
+  });
+
+  it('should render the Msg when Reservation item is Empty', async () => {
+    server.use(
+      rest.get(`http://localhost:8000/reservations/`, (req, res, ctx) => {
+        const query = req.url.searchParams;
+        const itemId = query.get('item.id');
+        if (itemId === '2') {
+          return res(ctx.status(200), ctx.json([]));
+        }
+      }),
+    );
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '2' });
+    render(
+      <MemoryRouter initialEntries={[`/item/:id`]}>
+        <ItemPage />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('現在予約は入っておりません')).toBeNull();
+    expect(
+      await screen.findByText('現在予約は入っておりません'),
+    ).toBeInTheDocument();
+  });
+
+  it('should call useNavigate when button was clicked', async () => {
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '1' });
+    render(
+        <MemoryRouter initialEntries={[`/item/:id`]}>
+          <ItemPage />
+        </MemoryRouter>
+    );
+    expect(screen.queryByTestId('btn-nav-1')).toBeNull();
+    expect(await screen.findByTestId('btn-nav-1')).toBeTruthy();
+    expect(screen.getAllByText('修正・削除')[0]).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('btn-nav-1'));
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/reserve/edit/1');
   });
 });

--- a/src/tests/Reserve.test.tsx
+++ b/src/tests/Reserve.test.tsx
@@ -12,40 +12,15 @@ import addReserveReducer from '../features/addReserveSlice';
 import { Provider } from 'react-redux';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { getUserInfo, sessionStorageMock } from './sessionStorage';
 
+// useNavigateのMock
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-function getUserInfo() {
-  const userInfo = window.sessionStorage.getItem('auth');
-  if (userInfo) {
-    return JSON.parse(userInfo);
-  }
-  return {};
-}
-
-type StoreType = {
-  [key: string]: string;
-};
-
-const sessionStorageMock = (() => {
-  let store: StoreType = {};
-
-  return {
-    getItem(key: string) {
-      return store[key] || null;
-    },
-    setItem(key: string, value: string) {
-      store[key] = value.toString();
-    },
-    clear() {
-      store = {};
-    },
-  };
-})();
-
+// windowオブジェクトのsessionStorageをsessionStorageMockプロパティに変更
 Object.defineProperty(window, 'sessionStorage', {
   value: sessionStorageMock,
 });

--- a/src/tests/sessionStorage.ts
+++ b/src/tests/sessionStorage.ts
@@ -1,0 +1,31 @@
+
+type StoreType = {
+  [key: string]: string;
+};
+// sessionStorageのMock
+export const sessionStorageMock = (() => {
+  let store: StoreType = {};
+
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+
+
+// ユーザー情報の取得
+export function getUserInfo() {
+  const userInfo = window.sessionStorage.getItem('auth');
+  if (userInfo) {
+    return JSON.parse(userInfo);
+  }
+  return {};
+}


### PR DESCRIPTION
## 謝罪
ブランチを分けてpushしたら#47とプルリク分けられるかなと思ったらできませんでした！見にくくしてすみません！
Completed.tsxとCompleted.test.tsxはsessionStorageのリファクタリング以外は#47と一緒なので#47を見てる場合は見なくていいです！

## やったこと
- ItemPage.test.tsxの実装
<img width="1470" alt="スクリーンショット 2023-04-25 14 53 41" src="https://user-images.githubusercontent.com/106084382/234190138-a3231528-949a-4fdf-bc15-379e81a10678.png">

- testで使用してsessionStorageのfnなどをリファクタリング

### useParams, useNavigateのテストをするにあたって実装した記事など
- useNavigateはjest.mockを使用した記述だとエラーが出たのでjest.spyOnを使用した記述にしてます。（原因究明中）
[参考にした記事](https://stackoverflow.com/questions/66284286/react-jest-mock-usenavigate)
[公式](https://jestjs.io/ja/docs/jest-object#jestspyonobject-methodname)

- useParams関連
  jest.requireActual('react-router-dom')　jest.spyOn(Router, 'useParams').mockReturnValue({ id: '1' });
   [参考にした記事1](https://www.tohuandkonsome.site/entry/2019/01/28/205928)
   [参考にした記事2](https://developer.mamezou-tech.com/testing/jest/jest-mock/#%E9%83%A8%E5%88%86%E7%9A%84%E3%81%AA%E3%83%A2%E3%83%83%E3%82%AF)
   [公式](https://jestjs.io/docs/mock-functions#mocking-partials)