### PR TITLE
マイページのテスト、UI一部変更

### DIFF
--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -65,22 +65,22 @@ export default function MyPage() {
                       }}
                     >
                       <Grid container spacing={2} paddingY={4}>
-                        <Grid item xs={2.5} data-testid="list-1">
+                        <Grid item xs={2.5}>
                           {reservation.date}
                         </Grid>
-                        <Grid item xs={3} data-testid="list-2">
+                        <Grid item xs={3}>
                           {reservation.startTime}~{reservation.endTime}
                         </Grid>
-                        <Grid item xs={4.5} data-testid="list-3">
+                        <Grid item xs={4.5}>
                           {reservation.item.name}
                         </Grid>
-                        <Grid item xs={2} data-testid="list-4">
+                        <Grid item xs={2}>
                           <Button
                             fullWidth
                             variant="contained"
                             sx={{ fontSize: 16 }}
-                            data-testid="edit-button"
                             onClick={() => clickHandler(reservation)}
+                            data-testid={`button-${reservation.id}`}
                           >
                             編集
                           </Button>

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -47,7 +47,7 @@ export default function MyPage() {
               borderRadius: 10,
             }}
           >
-            <Typography component="h1" variant="h4">
+            <Typography component="h1" variant="h4" data-testid="reserve-title">
               現在の予約状況を表示しています。
             </Typography>
             <Box sx={{ mt: 3 }}>
@@ -65,20 +65,21 @@ export default function MyPage() {
                       }}
                     >
                       <Grid container spacing={2} paddingY={4}>
-                        <Grid item xs={2.5}>
+                        <Grid item xs={2.5} data-testid="list-1">
                           {reservation.date}
                         </Grid>
-                        <Grid item xs={3}>
+                        <Grid item xs={3} data-testid="list-2">
                           {reservation.startTime}~{reservation.endTime}
                         </Grid>
-                        <Grid item xs={4.5}>
+                        <Grid item xs={4.5} data-testid="list-3">
                           {reservation.item.name}
                         </Grid>
-                        <Grid item xs={2}>
+                        <Grid item xs={2} data-testid="list-4">
                           <Button
                             fullWidth
                             variant="contained"
                             sx={{ fontSize: 16 }}
+                            data-testid="edit-button"
                             onClick={() => clickHandler(reservation)}
                           >
                             編集

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -40,11 +40,11 @@ export default function MyPage() {
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
-              paddingTop: 8,
-              paddingBottom: 8,
+              paddingY: 8,
               bgcolor: '#fff',
               boxShadow: 10,
               borderRadius: 10,
+              textAlign: 'center',
             }}
           >
             <Typography component="h1" variant="h4" data-testid="reserve-title">
@@ -53,7 +53,7 @@ export default function MyPage() {
             <Box sx={{ mt: 3 }}>
               {reservations.map((reservation: Reservation) => {
                 return (
-                  <Box sx={{ width: 800 }} key={reservation.id}>
+                  <Box sx={{ width: 1000 }} key={reservation.id}>
                     <Typography
                       variant="h4"
                       sx={{
@@ -65,16 +65,27 @@ export default function MyPage() {
                       }}
                     >
                       <Grid container spacing={2} paddingY={4}>
-                        <Grid item xs={2.5}>
-                          {reservation.date}
+                        <Grid
+                          item
+                          xs={2}
+                          data-testid={`date-${reservation.id}`}
+                        >
+                          {reservation.date.replaceAll('-', '/')}
                         </Grid>
-                        <Grid item xs={3}>
+                        <Grid
+                          item
+                          xs={2}
+                          data-testid={`time-${reservation.id}`}
+                        >
                           {reservation.startTime}~{reservation.endTime}
                         </Grid>
-                        <Grid item xs={4.5}>
+                        <Grid item xs={2.5}>
+                          {reservation.title}
+                        </Grid>
+                        <Grid item xs={4}>
                           {reservation.item.name}
                         </Grid>
-                        <Grid item xs={2}>
+                        <Grid item xs={1.5}>
                           <Button
                             fullWidth
                             variant="contained"

--- a/src/tests/Mypage.test.js
+++ b/src/tests/Mypage.test.js
@@ -66,7 +66,7 @@ afterAll(() => {
   server.close();
 });
 
-describe('Auth Component Test Cases', () => {
+describe('Mypage Component Test Cases', () => {
   it('1: should render all the elements correctly', async () => {
     render(<MyPage />);
     expect(screen.getByTestId('reserve-title')).toBeTruthy();

--- a/src/tests/Mypage.test.js
+++ b/src/tests/Mypage.test.js
@@ -60,7 +60,6 @@ describe('Auth Component Test Cases', () => {
   it('1-1: should render all the elements correctly', async () => {
     render(<MyPage />);
     expect(screen.getByTestId('reserve-title')).toBeTruthy();
-    expect(screen.getByTestId('list-1')).toBeTruthy();
-    expect(screen.getByTestId('list-2')).toBeTruthy();
+    expect(screen.getByTestId('button-1')).toBeTruthy();
   });
 });

--- a/src/tests/Mypage.test.js
+++ b/src/tests/Mypage.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import MyPage from '../components/MyPage';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const handlers = [
+  rest.get('http://localhost:8000/reservations', (req, res, ctx) => {
+    const query = req.url.searchParams;
+    const user = query.get('user');
+    console.log(user);
+    if (user.id === 1) {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          {
+            id: 1,
+            title: 'T社様訪問',
+            item: { id: 1, name: 'トヨタ・アルファードHYBRID' },
+            date: '2023-08-20',
+            startTime: '9:00',
+            endTime: '17:00',
+            user: { id: 1, name: 'Murakami' },
+          },
+          {
+            id: 2,
+            title: '営業拡販',
+            item: { id: 2, name: 'Surface - 02' },
+            date: '2023-08-20',
+            startTime: '9:00',
+            endTime: '17:00',
+            user: { id: 1, name: 'Murakami' },
+          },
+        ]),
+      );
+    }
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe('Auth Component Test Cases', () => {
+  it('1-1: should render all the elements correctly', async () => {
+    render(<MyPage />);
+    expect(screen.getByTestId('reserve-title')).toBeTruthy();
+    expect(screen.getByTestId('list-1')).toBeTruthy();
+    expect(screen.getByTestId('list-2')).toBeTruthy();
+  });
+});

--- a/src/tests/Mypage.test.js
+++ b/src/tests/Mypage.test.js
@@ -4,11 +4,17 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import MyPage from '../components/MyPage';
+import { getUserInfo, sessionStorageMock } from './sessionStorage';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
 
 const handlers = [
   rest.get('http://localhost:8000/reservations', (req, res, ctx) => {
@@ -47,6 +53,13 @@ const server = setupServer(...handlers);
 
 beforeAll(() => {
   server.listen();
+});
+beforeEach(() => {
+  window.sessionStorage.setItem(
+    'auth',
+    JSON.stringify({ id: 1, name: 'Murakami' }),
+  );
+  jest.restoreAllMocks();
 });
 afterEach(() => {
   server.resetHandlers();


### PR DESCRIPTION
## やったこと
- テスト：要素のレンダリング、編集ボタン押下時のページ遷移
- マイページ：日付の区切りを-から/に変更、予約時のタイトルが表示されていなかったので、表示

## やってないこと
- テスト：sessionStorageがない時にログインページに遷移する（時間があればやる）

## 画面イメージ
<img width="1179" alt="スクリーンショット 2023-04-27 15 41 52" src="https://user-images.githubusercontent.com/114968506/234781672-1364451e-ff4b-4ad9-b183-34c3749ce52b.png">

## カバレッジ率
<img width="592" alt="スクリーンショット 2023-04-27 15 41 02" src="https://user-images.githubusercontent.com/114968506/234781734-70f55bb3-f647-4e9a-9dba-963992fc9c1b.png">

